### PR TITLE
Update Markdown Extra for HTML5

### DIFF
--- a/lib/php-markdown-extra-1.2.4/markdown.php
+++ b/lib/php-markdown-extra-1.2.4/markdown.php
@@ -1767,7 +1767,7 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 	### HTML Block Parser ###
 	
 	# Tags that are always treated as block tags:
-	var $block_tags_re = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|address|form|fieldset|iframe|hr|legend';
+	var $block_tags_re = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|address|form|fieldset|iframe|hr|legend|aside|section|header|nav|article|footer|hgroup|figure';
 	
 	# Tags treated as block tags only if the opening tag is alone on it's line:
 	var $context_block_tags_re = 'script|noscript|math|ins|del';


### PR DESCRIPTION
I found that I needed to update the list of block level elements for Markdown in order to add compatibility for HTML5 elements.
